### PR TITLE
upgrade PyYAML to fix CVE-2017-18342

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ Jinja2==2.10
 jmespath==0.9.3
 MarkupSafe==1.1.0
 paramiko==2.4.2
-pkg-resources==0.0.0
 pyasn1==0.4.5
 pycparser==2.19
 PyNaCl==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ pyasn1==0.4.5
 pycparser==2.19
 PyNaCl==1.3.0
 python-dateutil==2.7.5
-PyYAML==3.13
+PyYAML==4.2b1
 s3transfer==0.1.13
 six==1.12.0


### PR DESCRIPTION
To fix [https://nvd.nist.gov/vuln/detail/CVE-2017-18342](CVE-2017-18342), we need to upgrade PyYAML to `4.2b1`.